### PR TITLE
Added break and continue errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ pub enum ErrorType {
     MathError,
     TypeError,
     SyntaxError,
+    RuntimeError,
 }
 
 #[derive(Clone, Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,8 +12,6 @@ pub enum Type {
     Array(Vec<Type>),
     Func(FuncType),
     Nil,
-    Break,
-    Continue,
 }
 
 impl Type {

--- a/test/test.eo
+++ b/test/test.eo
@@ -1,4 +1,4 @@
-var n = 1.3;
+var n = 13;
 
 println({
     var a = 0;


### PR DESCRIPTION
Added errors for break and continue statements, as well as creating a `Return` enum to store `Type`, `Break`, `Continue`, and `Err`.